### PR TITLE
Added a reverse loop to blog list

### DIFF
--- a/_pages/blog/index.html
+++ b/_pages/blog/index.html
@@ -22,7 +22,9 @@ open_graph:
 
 <section class="ph3 measure-wide pv4 center">
   <ul class="list pl0">
-    {% for post in site.blog limit:site.post_limit %}
+    {% assign sorted = site.blog | sort: 'date' %}
+    {% assign reversed = sorted | reverse %}
+    {% for post in reversed limit:site.post_limit %}
       <li class="pv3">
         <h2 class="mb0"><a href="{{ post.url | replace: "index", "" }}" class="link navy">{{ post.title }}</a></h2>
         <p class="black-40 mt1">{{ post.date | date: '%B %d, %Y' }}</p>


### PR DESCRIPTION
@danielepolencic Please note that the nested loop is required because the only way to combine the sort and reverse in one line causes a warning from liquid template engine.

The code works fine. I tested it by creating an article with today's date which appeared on top of the list. I did not commit the test article.